### PR TITLE
OMS : sepolicy: Allow system_server to set theme_prop

### DIFF
--- a/system_server.te
+++ b/system_server.te
@@ -353,6 +353,7 @@ set_prop(system_server, cppreopt_prop)
 
 # theme property
 get_prop(system_server, theme_prop)
+set_prop(system_server, theme_prop)
 
 # Create a socket for receiving info from wpa.
 type_transition system_server wifi_data_file:sock_file system_wpa_socket;


### PR DESCRIPTION
[ 6065.716763] init: avc:  denied  { set } for property=sys.refresh_theme
pid=1131 uid=1000 gid=1000 scontext=u:r:system_server:s0
tcontext=u:object_r:theme_prop:s0 tclass=property_service permissive=0

I am yet to spot any regressions this is causing, but better safe than sorry

Change-Id: I971b92dd3c074cda2ba0b49ffd256679dc4086de